### PR TITLE
Update PSSystemAdministrator.psm1

### DIFF
--- a/PSSystemAdministrator.psm1
+++ b/PSSystemAdministrator.psm1
@@ -2901,7 +2901,7 @@ function Remove-User{
     [CmdletBinding()]
     Param(
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$true)]
-        [string]$SamAccountName = $env:USERNAME
+        [string]$SamAccountName
     )
 
     begin{
@@ -2909,7 +2909,7 @@ function Remove-User{
     }
 
     process{
-        $users += Get-ADUser $Name
+        $users += Get-ADUser $SamAccountName
     }
 
     end{


### PR DESCRIPTION
Variable naming was not correct and prevented function from working.